### PR TITLE
Loot Randomizer Fixes and Improvements

### DIFF
--- a/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
+++ b/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
@@ -143,22 +143,6 @@ public class LootRandomizer {
         }
     }
 
-    // debug only remove later
-    public void printTableDebug (LootTable table, List<LootPool> pools) {
-        StringBuilder builder = new StringBuilder(table.getLootTableId().toString());
-        builder.append(" has pools -> [");
-        for (LootPool pool : pools) {
-            builder.append(pool.getName());
-            builder.append(",");
-        }
-        if (builder.lastIndexOf(",") != -1) {
-            builder.deleteCharAt(builder.lastIndexOf(","));
-        }
-        builder.append("]");
-
-        RandomizerCore.LOGGER.debug(builder.toString());
-    }
-
     private NonNullList<Item> generateRandomList(int amtItems) {
         NonNullList<Item> itemList = NonNullList.withSize(amtItems, Items.AIR);
         itemList.replaceAll(item -> ItemRandomizer.getRandomSimpleItem().item);

--- a/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
+++ b/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
@@ -103,17 +103,8 @@ public class LootRandomizer {
     }
 
     public void modifyEntries (LootPoolEntryContainer[] entries, List<Item> toReplace ) {
-        if (entries.length == 0) {
-            RandomizerCore.LOGGER.warn("Pool Entries ran out!");
-            return;
-        }
-
         for (int i = 0; i < entries.length; i++) {
             LootPoolEntryType type = entries[i].getType();
-
-            if (type == LootPoolEntries.EMPTY) {
-                continue;
-            }
 
             if (i == toReplace.size()) {
                 RandomizerCore.LOGGER.warn("Items to replace is empty!");

--- a/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
+++ b/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
@@ -65,14 +65,17 @@ public class LootRandomizer {
             if (data.containsPool(tableId, poolName)) {
                 newEntries = data.getPoolItems(tableId, poolName);
             } else {
-                newEntries = generateRandomList(calculateNewResults(entries, 0));
-                if (newEntries.size() == 0) return;
+                int itemsToGenerate = calculateNewResults(entries, 0);
+                if (itemsToGenerate < 1) return;
+                newEntries = generateRandomList(itemsToGenerate);
                 data.addPool(tableId, poolName, newEntries);
                 RandomizerCore.LOGGER.warn("No data for " + tableId + ", generating new data!");
             }
 
             modifyEntries(entries, newEntries);
+            ReflectionUtils.setField(LootPool.class, pool, 8, true); // freeze loot pool
         }
+        ReflectionUtils.setField(LootTable.class, table, 7, true); // freeze loot table
     }
 
     public int calculateNewResults (LootPoolEntryContainer[] entries, int depth) {

--- a/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
+++ b/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
@@ -95,20 +95,6 @@ public class LootRandomizer {
                 LootPoolEntryContainer[] extraEntries = ReflectionUtils.getField(CompositeEntryBase.class, (CompositeEntryBase) entry, 0);
                 size += calculateNewResults(extraEntries, depth++);
             }
-
-//            if (type == LootPoolEntries.GROUP) {
-//                RandomizerCore.LOGGER.warn("Group Entry");
-//                continue;
-//            }
-//
-//            if (type == LootPoolEntries.SEQUENCE) {
-//                RandomizerCore.LOGGER.warn("Sequence Entry");
-//                continue;
-//            }
-//
-//            if (type == LootPoolEntries.DYNAMIC) {
-//                RandomizerCore.LOGGER.warn("Dynamic Entry");
-//            }
         }
         return size;
     }

--- a/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
+++ b/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
@@ -266,8 +266,9 @@ public class LootRandomizer {
                 Object2ObjectOpenHashMap<String, NonNullList<Item>> poolMap = new Object2ObjectOpenHashMap<>();
                 poolMap.put(poolId, items);
                 lootTablePoolsMap.put(tableId, poolMap);
+            } else {
+                RandomizerCore.LOGGER.warn("A pool name in {} was null! Randomization will not be saved.", tableId);
             }
-            RandomizerCore.LOGGER.warn("A pool name in {} was null! Randomization will not be saved.", tableId);
         }
 
         public Boolean containsPool(ResourceLocation tableId, String poolId) {

--- a/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
+++ b/src/main/java/com/ghzdude/randomizer/LootRandomizer.java
@@ -70,7 +70,7 @@ public class LootRandomizer {
 
                 newEntries = generateRandomList(itemsToGenerate);
                 data.addPool(tableId, poolName, newEntries);
-                RandomizerCore.LOGGER.warn("No data for " + tableId + ", generating new data!");
+                RandomizerCore.LOGGER.warn("No data for {}, generating new data!", tableId);
             }
 
             modifyEntries(entries, newEntries);


### PR DESCRIPTION
Fixes a possible NullPointerException when the pool name is null. I don't know how the pool name could be null, as they should be autogenerated. Fixes #1.

also adds a depth check for `CalculateNewResults()` and other small improvements to the loot randomizer