### PR TITLE
Randomize Villager Trades

### DIFF
--- a/src/main/java/com/ghzdude/randomizer/RandomizerConfig.java
+++ b/src/main/java/com/ghzdude/randomizer/RandomizerConfig.java
@@ -21,6 +21,7 @@ public class RandomizerConfig {
     public static boolean randomizeChestLoot;
     public static boolean randomizeMobs;
     public static boolean randomizeMobAttributes;
+    public static boolean randomizeVillagerTrades;
 
     static {
         update();
@@ -42,6 +43,7 @@ public class RandomizerConfig {
         randomizeChestLoot = Holder.randomizeChestLoot.get();
         randomizeMobs = Holder.randomizeMobs.get();
         randomizeMobAttributes = Holder.randomizeMobAttributes.get();
+        randomizeVillagerTrades = Holder.randomizeVillagerTrades.get();
     }
 
     public static class Holder {
@@ -68,6 +70,7 @@ public class RandomizerConfig {
         public static ForgeConfigSpec.BooleanValue randomizeChestLoot;
         public static ForgeConfigSpec.BooleanValue randomizeMobs;
         public static ForgeConfigSpec.BooleanValue randomizeMobAttributes;
+        public static ForgeConfigSpec.BooleanValue randomizeVillagerTrades;
 
         public Holder(ForgeConfigSpec.Builder builder) {
 
@@ -126,6 +129,9 @@ public class RandomizerConfig {
 
             randomizeMobAttributes = builder.comment("Should the attributes of mobs be randomized when spawned? Defaults to false.")
                     .define("randomize_attributes", false);
+
+            randomizeVillagerTrades = builder.comment("Should villager trades give random output item stacks? Defaults to true.")
+                            .define("randomize_trades", true);
             builder.pop();
         }
 

--- a/src/main/java/com/ghzdude/randomizer/VillagerRandomizer.java
+++ b/src/main/java/com/ghzdude/randomizer/VillagerRandomizer.java
@@ -1,0 +1,20 @@
+package com.ghzdude.randomizer;
+
+import com.ghzdude.randomizer.util.RandomizerUtil;
+import net.minecraft.world.item.trading.MerchantOffer;
+
+public class VillagerRandomizer {
+    public static MerchantOffer randomizeOffer(MerchantOffer vanilla) {
+        int count = vanilla.getResult().getCount();
+        var stack = RandomizerUtil.itemToStack(RandomizerUtil.getRandom(ItemRandomizer.getValidItems()), count);
+
+        // MerchantOffer(ItemCost pBaseCostA, ItemStack pResult, int pMaxUses, int pXp, float pPriceMultiplier)
+        return new MerchantOffer(
+                vanilla.getItemCostA(),
+                stack,
+                vanilla.getMaxUses(),
+                vanilla.getXp(),
+                vanilla.getPriceMultiplier()
+        );
+    }
+}

--- a/src/main/java/com/ghzdude/randomizer/mixin/VillagerMixin.java
+++ b/src/main/java/com/ghzdude/randomizer/mixin/VillagerMixin.java
@@ -1,0 +1,40 @@
+package com.ghzdude.randomizer.mixin;
+
+import com.ghzdude.randomizer.VillagerRandomizer;
+import net.minecraft.world.entity.AgeableMob;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.npc.*;
+import net.minecraft.world.item.trading.Merchant;
+import net.minecraft.world.item.trading.MerchantOffer;
+import net.minecraft.world.item.trading.MerchantOffers;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.ArrayList;
+
+@Mixin(AbstractVillager.class)
+public abstract class VillagerMixin extends AgeableMob implements InventoryCarrier, Npc, Merchant {
+
+    protected VillagerMixin(EntityType<? extends AgeableMob> pEntityType, Level pLevel) {
+        super(pEntityType, pLevel);
+    }
+
+    @Inject(method = "addOffersFromItemListings", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/trading/MerchantOffers;add(Ljava/lang/Object;)Z"),
+            locals = LocalCapture.CAPTURE_FAILHARD)
+    public void randomizeOffer(MerchantOffers pGivenMerchantOffers, VillagerTrades.ItemListing[] pNewTrades, int pMaxNumbers,
+                               CallbackInfo ci, ArrayList<Object> arraylist, int i, MerchantOffer merchantoffer) {
+        if (randomizer$getThis() instanceof WanderingTrader) {
+            arraylist.add(VillagerRandomizer.randomizeOffer(merchantoffer));
+        }
+    }
+
+    @Unique
+    private AbstractVillager randomizer$getThis() {
+        return (AbstractVillager) (Object) this;
+    }
+}

--- a/src/main/java/com/ghzdude/randomizer/mixin/VillagerMixin.java
+++ b/src/main/java/com/ghzdude/randomizer/mixin/VillagerMixin.java
@@ -1,5 +1,6 @@
 package com.ghzdude.randomizer.mixin;
 
+import com.ghzdude.randomizer.RandomizerConfig;
 import com.ghzdude.randomizer.VillagerRandomizer;
 import net.minecraft.world.entity.npc.AbstractVillager;
 import net.minecraft.world.item.trading.MerchantOffer;
@@ -12,6 +13,10 @@ public abstract class VillagerMixin {
 
     @ModifyVariable(method = "addOffersFromItemListings", at = @At(value = "LOAD", ordinal = 1))
     public MerchantOffer randomizeOffer(MerchantOffer merchantoffer) {
-        return VillagerRandomizer.randomizeOffer(merchantoffer);
+        if (RandomizerConfig.randomizeVillagerTrades) {
+            return VillagerRandomizer.randomizeOffer(merchantoffer);
+        } else {
+            return merchantoffer;
+        }
     }
 }

--- a/src/main/java/com/ghzdude/randomizer/mixin/VillagerMixin.java
+++ b/src/main/java/com/ghzdude/randomizer/mixin/VillagerMixin.java
@@ -1,40 +1,17 @@
 package com.ghzdude.randomizer.mixin;
 
 import com.ghzdude.randomizer.VillagerRandomizer;
-import net.minecraft.world.entity.AgeableMob;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.npc.*;
-import net.minecraft.world.item.trading.Merchant;
+import net.minecraft.world.entity.npc.AbstractVillager;
 import net.minecraft.world.item.trading.MerchantOffer;
-import net.minecraft.world.item.trading.MerchantOffers;
-import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
-
-import java.util.ArrayList;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(AbstractVillager.class)
-public abstract class VillagerMixin extends AgeableMob implements InventoryCarrier, Npc, Merchant {
+public abstract class VillagerMixin {
 
-    protected VillagerMixin(EntityType<? extends AgeableMob> pEntityType, Level pLevel) {
-        super(pEntityType, pLevel);
-    }
-
-    @Inject(method = "addOffersFromItemListings", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/trading/MerchantOffers;add(Ljava/lang/Object;)Z"),
-            locals = LocalCapture.CAPTURE_FAILHARD)
-    public void randomizeOffer(MerchantOffers pGivenMerchantOffers, VillagerTrades.ItemListing[] pNewTrades, int pMaxNumbers,
-                               CallbackInfo ci, ArrayList<Object> arraylist, int i, MerchantOffer merchantoffer) {
-        if (randomizer$getThis() instanceof WanderingTrader) {
-            arraylist.add(VillagerRandomizer.randomizeOffer(merchantoffer));
-        }
-    }
-
-    @Unique
-    private AbstractVillager randomizer$getThis() {
-        return (AbstractVillager) (Object) this;
+    @ModifyVariable(method = "addOffersFromItemListings", at = @At(value = "LOAD", ordinal = 1))
+    public MerchantOffer randomizeOffer(MerchantOffer merchantoffer) {
+        return VillagerRandomizer.randomizeOffer(merchantoffer);
     }
 }

--- a/src/main/resources/mixins.randomizer.json
+++ b/src/main/resources/mixins.randomizer.json
@@ -8,6 +8,7 @@
     "AdvancementManagerMixin",
     "IngredientMixin",
     "RandomizeLootMixin",
+    "VillagerMixin",
     "recipe.CookingMixin",
     "recipe.ShapedMixin",
     "recipe.ShapelessMixin",


### PR DESCRIPTION
Adds a config for randomizing the outputs of villager trades. Affects the wandering trader along with normal villagers.